### PR TITLE
feat: add free models endpoint

### DIFF
--- a/src/app/api/free-models/route.ts
+++ b/src/app/api/free-models/route.ts
@@ -1,0 +1,18 @@
+export async function GET() {
+  const url = "https://openrouter.ai/api/frontend/models/find?max_price=0";
+
+  try {
+    const response = await fetch(url);
+
+    if (!response.ok) {
+      return Response.json({ error: "Failed to fetch models" }, { status: response.status });
+    }
+
+    const json = await response.json();
+    const models = (json?.data?.models ?? []).map((model: any) => model.permaslug);
+
+    return Response.json({ models });
+  } catch (error) {
+    return Response.json({ error: "Failed to fetch models" }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary
- add endpoint at `/api/free-models` that returns free OpenRouter models

## Testing
- `pnpm run lint` *(fails: Invalid package manager specification in package.json (pnpm@*))*
- `pnpm run typecheck` *(fails: Invalid package manager specification in package.json (pnpm@*))*

------
https://chatgpt.com/codex/tasks/task_e_688fc05200448330bf62bc886164c04c